### PR TITLE
fix: skipping mysql query modules executions in dry run

### DIFF
--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -31,7 +31,9 @@
       - ''
       - "{{ item.Host }}"
   loop: "{{ _mariadb_anonymous_hosts.query_result | first }}"
-  when: _mariadb_anonymous_hosts.rowcount[0] != 0
+  when:
+    - not ansible_check_mode
+    - _mariadb_anonymous_hosts.rowcount[0] != 0
 
 - name: Get list of hosts for the root user.
   community.mysql.mysql_query:
@@ -41,7 +43,6 @@
     positional_args:
       - "{{ mariadb_admin_user }}"
   register: _mariadb_root_hosts
-  check_mode: false
 
 - name: Disallow root login remotely
   community.mysql.mysql_user:
@@ -51,6 +52,7 @@
     priv: "*.*:ALL,GRANT"
     state: absent
   loop: '{{ _mariadb_root_hosts.query_result[0] | rejectattr("Host", "in", "localhost,::1,127.0.0.1") | list }}'
+  when: not ansible_check_mode
 
 - name: Update MariaDB root password for localhost root account
   community.mysql.mysql_user:
@@ -60,6 +62,7 @@
     host: "localhost"
   register: _mariadb_root_password_update
   when:
+    - not ansible_check_mode
     - _mariadb_root_hosts.rowcount[0] != 0
     - mariadb_admin_force_password_update
 

--- a/vars/debian-family.yml
+++ b/vars/debian-family.yml
@@ -15,6 +15,7 @@ _mariadb_dependencies_packages:
   - nano
   - cron
   - openssl
+  - pkg-config
 _mariadb_packages:
   - mariadb-server
   - mariadb-client

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ ansible_distro_major_version: "{{ ansible_distribution_major_version | lower | r
 _ansible_os_family: "{{ ansible_os_family | lower }}"
 
 _mariadb_dependencies_pip_packages:
-  - mysqlclient
+  - mysqlclient<=2.2.0
 
 _mariadb_systemd_override: "{{ mariadb_systemd_override }}"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With respects to the issues #2 I updated the `secure-installation.yaml` to skip `mysql_query` tasks that depended on previous `mysql_query` tasks registered variables as those registered were not properly constructed.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow running the role in dry run without errors
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #2 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
The appropriate tasks are correctly skipped in dry-run.

![image](https://github.com/claranet/ansible-role-mariadb/assets/50207516/e9445cc6-d46a-407a-b0b8-39cae7269436)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.