### PR TITLE
Fix/mysqlclient install error on ubuntu 20.04 and 22.04

### DIFF
--- a/vars/debian-family.yml
+++ b/vars/debian-family.yml
@@ -15,6 +15,7 @@ _mariadb_dependencies_packages:
   - nano
   - cron
   - openssl
+  - pkg-config
 _mariadb_packages:
   - mariadb-server
   - mariadb-client

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ ansible_distro_major_version: "{{ ansible_distribution_major_version | lower | r
 _ansible_os_family: "{{ ansible_os_family | lower }}"
 
 _mariadb_dependencies_pip_packages:
-  - mysqlclient
+  - mysqlclient<=2.2.0
 
 _mariadb_systemd_override: "{{ mariadb_systemd_override }}"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The latest mysqlclient python package required additionnal packages when being installed ubuntu 20.04 and 22.04. As a result we added the extra packages and locked the version to the current latest one 2.2.0 to prevent further unexpected breakages.


## Motivation and Context
Fixes issue #4 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- molecule converge -s default
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
