### PR TITLE
Migrated Github workflows to molecule v5 and added support for Ansible 2.16

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -40,11 +40,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: "${{ github.repository }}"
-      - name: molecule
-        uses: robertdebock/molecule-action@4.0.9
+      - name: Run ansible lint
+        uses: ansible/ansible-lint-action@main
         with:
-          command: lint
-          scenario: ${{ fromJson(needs.setup.outputs.scenarios)[0] }}
+          path: "."
 
   test:
     name: Scenario "${{ matrix.scenario }}" on ${{ matrix.config.image }}:${{ matrix.config.tag }}
@@ -94,10 +93,14 @@ jobs:
         with:
           path: "${{ github.repository }}"
       - name: molecule
-        uses: robertdebock/molecule-action@4.0.9
+        uses: gofrolist/molecule-action@v2
         with:
+          # molecule_options: --debug
+          molecule_command: test
+          molecule_args: --scenario-name ${{ matrix.scenario }} -d docker
+          molecule_working_dir: "${{ github.repository }}"
+        env:
           image: ${{ matrix.config.image }}
           tag: ${{ matrix.config.tag }}
-          scenario: ${{ matrix.scenario }}
-        env:
           name: ${{ matrix.config.name }}
+

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: "${{ github.repository }}"
       - name: Run ansible lint
-        uses: ansible/ansible-lint-action@main
+        uses: ansible/ansible-lint-action@v6.17.0
         with:
           path: "."
 

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
-  name: galaxy
+  name: shell
+  command: "${MOLECULE_SCENARIO_DIRECTORY}/tools/install-dependencies"
 
 driver:
   name: docker

--- a/molecule/cluster/tools
+++ b/molecule/cluster/tools
@@ -1,0 +1,1 @@
+../shared/tools/

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
-  name: galaxy
+  name: shell
+  command: "${MOLECULE_SCENARIO_DIRECTORY}/tools/install-dependencies"
 
 driver:
   name: docker

--- a/molecule/default/tools
+++ b/molecule/default/tools
@@ -1,0 +1,1 @@
+../shared/tools/

--- a/molecule/encryption-auto/molecule.yml
+++ b/molecule/encryption-auto/molecule.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
-  name: galaxy
+  name: shell
+  command: "${MOLECULE_SCENARIO_DIRECTORY}/tools/install-dependencies"
 
 driver:
   name: docker

--- a/molecule/encryption-auto/tools
+++ b/molecule/encryption-auto/tools
@@ -1,0 +1,1 @@
+../shared/tools/

--- a/molecule/encryption/molecule.yml
+++ b/molecule/encryption/molecule.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
-  name: galaxy
+  name: shell
+  command: "${MOLECULE_SCENARIO_DIRECTORY}/tools/install-dependencies"
 
 driver:
   name: docker

--- a/molecule/encryption/tools
+++ b/molecule/encryption/tools
@@ -1,0 +1,1 @@
+../shared/tools/

--- a/molecule/shared/tools/install-dependencies
+++ b/molecule/shared/tools/install-dependencies
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+python3 -m pip install -r "$(dirname "$0")/requirements.txt"
+ansible-galaxy install -r "$(dirname "$0")/requirements.yml"

--- a/molecule/shared/tools/requirements.txt
+++ b/molecule/shared/tools/requirements.txt
@@ -1,0 +1,1 @@
+pytest-testinfra

--- a/molecule/shared/tools/requirements.yml
+++ b/molecule/shared/tools/requirements.yml
@@ -1,0 +1,4 @@
+collections:
+  - name: community.general
+  - name: community.mysql
+    version: 3.7.2

--- a/tasks/replication-replica.yml
+++ b/tasks/replication-replica.yml
@@ -21,7 +21,7 @@
   community.mysql.mysql_replication:
     mode: getprimary
     login_unix_socket: "{{ mariadb_replication_primary_socket }}"
-  delegate_to: "{{ mariadb_replication_primary_inventory_host }}"
+  delegate_to: "{{ mariadb_replication_primary_inventory_host | d(omit, true) }}"
   register: _mariadb_primary
   when:
     - (_mariadb_replica.Is_Replica is defined and not _mariadb_replica.Is_Replica) or (_mariadb_replica.Is_Replica is not defined and replica is failed)


### PR DESCRIPTION
## Description

This PR migrates the existing GitHub workflow to Molecule version 5 and added support to Ansible 2.16.

## Changes Made

- Updated Molecule configuration files to version 5.
- Introduced `| d(omit, true)` to the `delegate_to: "{{ mariadb_replication_primary_inventory_host | d(omit, true) }}"` expression in `tasks/replication-replica.yml`. This addition is intended to handle potential errors with Ansible version 2.16, especially when the variable `mariadb_replication_primary_inventory_host` is empty.
   Solution from https://github.com/ansible/ansible/issues/82264

Closes #10