### PR TITLE
Typo fix (replica variable used instead of _mariadb_replica) and centos stream 8 support dropped

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -61,9 +61,6 @@ jobs:
           - name: centos
             image: "quay.io/centos/centos"
             tag: "centos8"
-          - name: centos
-            image: "quay.io/centos/centos"
-            tag: "stream8"
           - name: rocky
             image: "rockylinux"
             tag: 8.7

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Debian 11         | No   | No   | Yes  | Yes |  Yes
 Debian 12         | No   | No   | No   | No  |  Yes
 Ubuntu 20.04,18.04| Yes  | Yes  | Yes  | Yes |  Yes
 Ubuntu 22.04      | No   | No   | No   | Yes |  Yes
-CentOS 8,Stream8  | Yes  | Yes  | Yes  | Yes |  Yes
+CentOS 8          | Yes  | Yes  | Yes  | Yes |  Yes
 Fedora 37         | No   | No   | No   | Yes |  Yes
 
 

--- a/tasks/replication-replica.yml
+++ b/tasks/replication-replica.yml
@@ -24,7 +24,7 @@
   delegate_to: "{{ mariadb_replication_primary_inventory_host | d(omit, true) }}"
   register: _mariadb_primary
   when:
-    - (_mariadb_replica.Is_Replica is defined and not _mariadb_replica.Is_Replica) or (_mariadb_replica.Is_Replica is not defined and replica is failed)
+    - (_mariadb_replica.Is_Replica is defined and not _mariadb_replica.Is_Replica) or (_mariadb_replica.Is_Replica is not defined and _mariadb_replica is failed)
 
 - name: "Configure replication on the replica."
   community.mysql.mysql_replication:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR does the following: 
- Fixes a typo caused by using the wrong variable name ([replica variable used instead of _mariadb_replica](https://github.com/claranet/ansible-role-mariadb/blob/main/tasks/replication-replica.yml#L27)) that also caused issues during dry-run in a replicated setup.
- Drops support for centos stream 8 cause it reached eol (and causes ci testing to break).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR closes #17 and closes #19 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally testing the cluster scenario with `molecule converge -s cluster -- --check`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
