### PR TITLE
fix(setup-vars): declare _mariadb_not_installed as boolean instead of string

### DIFF
--- a/tasks/setup-vars.yml
+++ b/tasks/setup-vars.yml
@@ -7,7 +7,7 @@
 
 - name: 'Set fact _mariadb_not_installed'
   ansible.builtin.set_fact:
-    _mariadb_not_installed: "{{ 'true' if not _mariadb_installed_.stdout else 'false' }}"
+    _mariadb_not_installed: "{{ not _mariadb_installed_.stdout }}"
 
 - name: "Build proxy environnement to enable/disable proxy use for general internet usage and package manager actions"
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Description
`_mariadb_not_installed` was set using quoted string literals `'true'`/`'false'` instead of actual booleans.

```yaml
# before
_mariadb_not_installed: "{{ 'true' if not _mariadb_installed_.stdout else 'false' }}"

# after
_mariadb_not_installed: "{{ not _mariadb_installed_.stdout }}"
```

Closes #22

## Motivation and Context
In Ansible, any non-empty string is truthy in `when:` conditions — including the string `"false"`. This meant `_mariadb_not_installed` always evaluated to `true` regardless of whether MariaDB was already installed, causing installation tasks to always run on already-provisioned hosts.

## How Has This Been Tested?
Tested via CI jobs.

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.